### PR TITLE
Create dedicated memory pools for Wi-Fi

### DIFF
--- a/fw_if/umac_if/src/system/fmac_api.c
+++ b/fw_if/umac_if/src/system/fmac_api.c
@@ -60,7 +60,7 @@ static enum nrf_wifi_status nrf_wifi_sys_fmac_init_tx(struct nrf_wifi_fmac_dev_c
 		sys_fpriv->data_config.max_tx_aggregation *
 		sizeof(struct nrf_wifi_fmac_buf_map_info));
 
-	sys_dev_ctx->tx_buf_info = nrf_wifi_osal_mem_zalloc(size);
+	sys_dev_ctx->tx_buf_info = nrf_wifi_osal_data_mem_zalloc(size);
 
 	if (!sys_dev_ctx->tx_buf_info) {
 		nrf_wifi_osal_log_err("%s: No space for TX buf info",
@@ -86,7 +86,7 @@ static void nrf_wifi_sys_fmac_deinit_tx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_c
 
 	tx_deinit(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_free(sys_dev_ctx->tx_buf_info);
+	nrf_wifi_osal_data_mem_free(sys_dev_ctx->tx_buf_info);
 }
 
 #endif /* NRF70_DATA_TX */
@@ -106,7 +106,7 @@ static enum nrf_wifi_status nrf_wifi_sys_fmac_init_rx(struct nrf_wifi_fmac_dev_c
 
 	size = (sys_fpriv->num_rx_bufs * sizeof(struct nrf_wifi_fmac_buf_map_info));
 
-	sys_dev_ctx->rx_buf_info = nrf_wifi_osal_mem_zalloc(size);
+	sys_dev_ctx->rx_buf_info = nrf_wifi_osal_data_mem_zalloc(size);
 
 	if (!sys_dev_ctx->rx_buf_info) {
 		nrf_wifi_osal_log_err("%s: No space for RX buf info",
@@ -182,7 +182,7 @@ static enum nrf_wifi_status nrf_wifi_sys_fmac_deinit_rx(struct nrf_wifi_fmac_dev
 		}
 	}
 
-	nrf_wifi_osal_mem_free(sys_dev_ctx->rx_buf_info);
+	nrf_wifi_osal_data_mem_free(sys_dev_ctx->rx_buf_info);
 
 	sys_dev_ctx->rx_buf_info = NULL;
 out:

--- a/hw_if/hal/src/common/hal_api_common.c
+++ b/hw_if/hal/src/common/hal_api_common.c
@@ -695,9 +695,9 @@ void nrf_wifi_hal_dev_rem(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_hal);
 	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_rx);
 
-	nrf_wifi_utils_q_free(hal_dev_ctx->event_q);
+	nrf_wifi_utils_ctrl_q_free(hal_dev_ctx->event_q);
 
-	nrf_wifi_utils_q_free(hal_dev_ctx->cmd_q);
+	nrf_wifi_utils_ctrl_q_free(hal_dev_ctx->cmd_q);
 
 #ifdef NRF_WIFI_LOW_POWER
 	hal_rpu_ps_deinit(hal_dev_ctx);

--- a/hw_if/hal/src/offload_raw_tx/hal_api.c
+++ b/hw_if/hal/src/offload_raw_tx/hal_api.c
@@ -110,7 +110,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_off_raw_tx_hal_dev_add(struct nrf_wifi_hal
 
 	hal_dev_ctx->num_cmds = RPU_CMD_START_MAGIC;
 
-	hal_dev_ctx->cmd_q = nrf_wifi_utils_q_alloc();
+	hal_dev_ctx->cmd_q = nrf_wifi_utils_ctrl_q_alloc();
 
 	if (!hal_dev_ctx->cmd_q) {
 		nrf_wifi_osal_log_err("%s: Unable to allocate command queue",
@@ -118,7 +118,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_off_raw_tx_hal_dev_add(struct nrf_wifi_hal
 		goto hal_dev_free;
 	}
 
-	hal_dev_ctx->event_q = nrf_wifi_utils_q_alloc();
+	hal_dev_ctx->event_q = nrf_wifi_utils_ctrl_q_alloc();
 
 	if (!hal_dev_ctx->event_q) {
 		nrf_wifi_osal_log_err("%s: Unable to allocate event queue",
@@ -217,9 +217,9 @@ lock_rx_free:
 lock_hal_free:
 	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_hal);
 event_q_free:
-	nrf_wifi_utils_q_free(hal_dev_ctx->event_q);
+	nrf_wifi_utils_ctrl_q_free(hal_dev_ctx->event_q);
 cmd_q_free:
-	nrf_wifi_utils_q_free(hal_dev_ctx->cmd_q);
+	nrf_wifi_utils_ctrl_q_free(hal_dev_ctx->cmd_q);
 hal_dev_free:
 	nrf_wifi_osal_mem_free(hal_dev_ctx);
 	hal_dev_ctx = NULL;

--- a/hw_if/hal/src/radio_test/hal_api.c
+++ b/hw_if/hal/src/radio_test/hal_api.c
@@ -109,7 +109,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_rt_hal_dev_add(struct nrf_wifi_hal_priv *h
 
 	hal_dev_ctx->num_cmds = RPU_CMD_START_MAGIC;
 
-	hal_dev_ctx->cmd_q = nrf_wifi_utils_q_alloc();
+	hal_dev_ctx->cmd_q = nrf_wifi_utils_ctrl_q_alloc();
 
 	if (!hal_dev_ctx->cmd_q) {
 		nrf_wifi_osal_log_err("%s: Unable to allocate command queue",
@@ -117,7 +117,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_rt_hal_dev_add(struct nrf_wifi_hal_priv *h
 		goto hal_dev_free;
 	}
 
-	hal_dev_ctx->event_q = nrf_wifi_utils_q_alloc();
+	hal_dev_ctx->event_q = nrf_wifi_utils_ctrl_q_alloc();
 
 	if (!hal_dev_ctx->event_q) {
 		nrf_wifi_osal_log_err("%s: Unable to allocate event queue",
@@ -216,9 +216,9 @@ lock_rx_free:
 lock_hal_free:
 	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_hal);
 event_q_free:
-	nrf_wifi_utils_q_free(hal_dev_ctx->event_q);
+	nrf_wifi_utils_ctrl_q_free(hal_dev_ctx->event_q);
 cmd_q_free:
-	nrf_wifi_utils_q_free(hal_dev_ctx->cmd_q);
+	nrf_wifi_utils_ctrl_q_free(hal_dev_ctx->cmd_q);
 hal_dev_free:
 	nrf_wifi_osal_mem_free(hal_dev_ctx);
 	hal_dev_ctx = NULL;

--- a/hw_if/hal/src/system/hal_api.c
+++ b/hw_if/hal/src/system/hal_api.c
@@ -452,7 +452,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_sys_hal_dev_add(struct nrf_wifi_hal_priv *
 
 	hal_dev_ctx->num_cmds = RPU_CMD_START_MAGIC;
 
-	hal_dev_ctx->cmd_q = nrf_wifi_utils_q_alloc();
+	hal_dev_ctx->cmd_q = nrf_wifi_utils_ctrl_q_alloc();
 
 	if (!hal_dev_ctx->cmd_q) {
 		nrf_wifi_osal_log_err("%s: Unable to allocate command queue",
@@ -460,7 +460,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_sys_hal_dev_add(struct nrf_wifi_hal_priv *
 		goto hal_dev_free;
 	}
 
-	hal_dev_ctx->event_q = nrf_wifi_utils_q_alloc();
+	hal_dev_ctx->event_q = nrf_wifi_utils_ctrl_q_alloc();
 
 	if (!hal_dev_ctx->event_q) {
 		nrf_wifi_osal_log_err("%s: Unable to allocate event queue",
@@ -608,9 +608,9 @@ lock_rx_free:
 lock_hal_free:
 	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_hal);
 event_q_free:
-	nrf_wifi_utils_q_free(hal_dev_ctx->event_q);
+	nrf_wifi_utils_ctrl_q_free(hal_dev_ctx->event_q);
 cmd_q_free:
-	nrf_wifi_utils_q_free(hal_dev_ctx->cmd_q);
+	nrf_wifi_utils_ctrl_q_free(hal_dev_ctx->cmd_q);
 hal_dev_free:
 	nrf_wifi_osal_mem_free(hal_dev_ctx);
 	hal_dev_ctx = NULL;

--- a/os_if/inc/osal_api.h
+++ b/os_if/inc/osal_api.h
@@ -41,7 +41,7 @@ void nrf_wifi_osal_init(const struct nrf_wifi_osal_ops *ops);
 void nrf_wifi_osal_deinit(void);
 
 /**
- * @brief Allocate memory.
+ * @brief Allocate memory for control path requests.
  * @param size Size of the memory to be allocated in bytes.
  *
  * Allocates memory of @p size bytes and returns a pointer to the start
@@ -52,7 +52,7 @@ void nrf_wifi_osal_deinit(void);
 void *nrf_wifi_osal_mem_alloc(size_t size);
 
 /**
- * @brief Allocated zero-initialized memory.
+ * @brief Allocated zero-initialized memory for control path requests.
  * @param size Size of the memory to be allocated in bytes.
  *
  * Allocates zero-initialized memory of @p size bytes and returns a pointer to the start
@@ -63,13 +63,37 @@ void *nrf_wifi_osal_mem_alloc(size_t size);
 void *nrf_wifi_osal_mem_zalloc(size_t size);
 
 /**
- * @brief Free previously allocated memory.
+ * @brief Allocated zero-initialized memory for data.
+ *
+ * @size: Size of the memory to be allocated in bytes.
+ *
+ * Allocates memory of @size bytes, zeroes it out and returns a pointer to the
+ * start of the memory allocated.
+ *
+ * @return: Pointer to start of allocated memory or NULL.
+ */
+void *nrf_wifi_osal_data_mem_zalloc(size_t size);
+
+/**
+ * @brief Free previously allocated memory for control path requests.
  * @param buf Pointer to the memory to be freed.
  *
  * Free up memory which has been allocated using  nrf_wifi_osal_mem_alloc or
  * nrf_wifi_osal_mem_zalloc.
  */
 void nrf_wifi_osal_mem_free(void *buf);
+
+/**
+ * @brief Free previously allocated memory for data.
+ *
+ * @buf: Pointer to the memory to be freed.
+ *
+ * Free up memory which has been allocated using @nrf_wifi_osal_mem_alloc or
+ * @nrf_wifi_osal_mem_zalloc.
+ *
+ * @return: None.
+ */
+void nrf_wifi_osal_data_mem_free(void *buf);
 
 /**
  * @brief Copy contents from one memory location to another.
@@ -341,6 +365,22 @@ void *nrf_wifi_osal_llist_alloc(void);
  */
 void nrf_wifi_osal_llist_free(void *llist);
 
+/**
+ * @brief Allocate a linked list.
+ *
+ * Allocate a linked list.
+ *
+ * @return Pointer to the allocated linked list on success, NULL on error.
+ */
+void *nrf_wifi_osal_ctrl_llist_alloc(void);
+
+/**
+ * @brief Free a linked list.
+ * @param llist Pointer to a linked list.
+ *
+ * Frees a linked list (llist) allocated by  nrf_wifi_osal_llist_alloc.
+ */
+void nrf_wifi_osal_ctrl_llist_free(void *llist);
 
 /**
  * @brief Initialize a linked list.

--- a/os_if/inc/osal_ops.h
+++ b/os_if/inc/osal_ops.h
@@ -28,13 +28,13 @@ struct nrf_wifi_osal_ops {
 	/**
 	 * @brief Allocate memory.
 	 *
-	 * @param size The size of the memory to allocate.
+	 * @param size The size of the memory to allocate for control messages.
 	 * @return A pointer to the start of the allocated memory.
 	 */
 	void *(*mem_alloc)(size_t size);
 
 	/**
-	 * @brief Allocate zero-initialized memory.
+	 * @brief Allocate zero-initialized memory for control messages.
 	 *
 	 * @param size The size of the memory to allocate.
 	 * @return A pointer to the start of the allocated memory.
@@ -42,11 +42,26 @@ struct nrf_wifi_osal_ops {
 	void *(*mem_zalloc)(size_t size);
 
 	/**
-	 * @brief Free allocated memory.
+	 * @brief Free memory allocated for control messages.
 	 *
 	 * @param buf A pointer to the memory to free.
 	 */
 	void (*mem_free)(void *buf);
+
+	/**
+	 * @brief Allocate zero-initialized memory for data.
+	 *
+	 * @param size The size of the memory to allocate.
+	 * @return A pointer to the start of the allocated memory.
+	 */
+	void *(*data_mem_zalloc)(size_t size);
+
+	/**
+	 * @brief Free memory allocated for data.
+	 *
+	 * @param buf A pointer to the memory to free.
+	 */
+	void (*data_mem_free)(void *buf);
 
 	/**
 	 * @brief Copy memory.
@@ -321,11 +336,25 @@ struct nrf_wifi_osal_ops {
 	void *(*llist_alloc)(void);
 
 	/**
+	 * @brief Allocate a linked list for control path.
+	 *
+	 * @return A pointer to the allocated linked list.
+	 */
+	void *(*ctrl_llist_alloc)(void);
+
+	/**
 	 * @brief Free a linked list.
 	 *
 	 * @param llist A pointer to the linked list to free.
 	 */
 	void (*llist_free)(void *llist);
+
+	/**
+	 * @brief Free a linked list for control path.
+	 *
+	 * @param llist A pointer to the linked list to free.
+	 */
+	void (*ctrl_llist_free)(void *llist);
 
 	/**
 	 * @brief Initialize a linked list.

--- a/os_if/src/osal.c
+++ b/os_if/src/osal.c
@@ -37,9 +37,21 @@ void *nrf_wifi_osal_mem_zalloc(size_t size)
 }
 
 
+void *nrf_wifi_osal_data_mem_zalloc(size_t size)
+{
+	return os_ops->data_mem_zalloc(size);
+}
+
+
 void nrf_wifi_osal_mem_free(void *buf)
 {
 	os_ops->mem_free(buf);
+}
+
+
+void nrf_wifi_osal_data_mem_free(void *buf)
+{
+	os_ops->data_mem_free(buf);
 }
 
 
@@ -251,12 +263,20 @@ void *nrf_wifi_osal_llist_alloc(void)
 	return os_ops->llist_alloc();
 }
 
+void *nrf_wifi_osal_ctrl_llist_alloc(void)
+{
+	return os_ops->ctrl_llist_alloc();
+}
 
 void nrf_wifi_osal_llist_free(void *llist)
 {
 	return os_ops->llist_free(llist);
 }
 
+void nrf_wifi_osal_ctrl_llist_free(void *llist)
+{
+	return os_ops->ctrl_llist_free(llist);
+}
 
 void nrf_wifi_osal_llist_init(void *llist)
 {

--- a/utils/inc/list.h
+++ b/utils/inc/list.h
@@ -18,6 +18,10 @@ void *nrf_wifi_utils_list_alloc(void);
 
 void nrf_wifi_utils_list_free(void *list);
 
+void *nrf_wifi_utils_ctrl_list_alloc(void);
+
+void nrf_wifi_utils_ctrl_list_free(void *list);
+
 enum nrf_wifi_status nrf_wifi_utils_list_add_tail(void *list,
 						  void *data);
 

--- a/utils/inc/queue.h
+++ b/utils/inc/queue.h
@@ -18,6 +18,10 @@ void *nrf_wifi_utils_q_alloc(void);
 
 void nrf_wifi_utils_q_free(void *q);
 
+void *nrf_wifi_utils_ctrl_q_alloc(void);
+
+void nrf_wifi_utils_ctrl_q_free(void *q);
+
 enum nrf_wifi_status nrf_wifi_utils_q_enqueue(void *q,
 					      void *q_node);
 

--- a/utils/src/list.c
+++ b/utils/src/list.c
@@ -31,12 +31,34 @@ out:
 
 }
 
+void *nrf_wifi_utils_ctrl_list_alloc(void)
+{
+	void *list = NULL;
+
+	list = nrf_wifi_osal_ctrl_llist_alloc();
+
+	if (!list) {
+		nrf_wifi_osal_log_err("%s: Unable to allocate list",
+				      __func__);
+		goto out;
+	}
+
+	nrf_wifi_osal_llist_init(list);
+
+out:
+	return list;
+
+}
 
 void nrf_wifi_utils_list_free(void *list)
 {
 	nrf_wifi_osal_llist_free(list);
 }
 
+void nrf_wifi_utils_ctrl_list_free(void *list)
+{
+	nrf_wifi_osal_ctrl_llist_free(list);
+}
 
 enum nrf_wifi_status nrf_wifi_utils_list_add_tail(void *list,
 						  void *data)

--- a/utils/src/queue.c
+++ b/utils/src/queue.c
@@ -17,12 +17,20 @@ void *nrf_wifi_utils_q_alloc(void)
 	return nrf_wifi_utils_list_alloc();
 }
 
+void *nrf_wifi_utils_ctrl_q_alloc(void)
+{
+	return nrf_wifi_utils_ctrl_list_alloc();
+}
 
 void nrf_wifi_utils_q_free(void *q)
 {
 	nrf_wifi_utils_list_free(q);
 }
 
+void nrf_wifi_utils_ctrl_q_free(void *q)
+{
+	nrf_wifi_utils_ctrl_list_free(q);
+}
 
 enum nrf_wifi_status nrf_wifi_utils_q_enqueue(void *q,
 					      void *data)


### PR DESCRIPTION
Create dedicated memory pools for Wi-Fi data and
management paths. Introduce corresponding memory
allocation/deallocation calls.