### PR TITLE
scripts: Fix the path to the template

### DIFF
--- a/scripts/update_blobs.py
+++ b/scripts/update_blobs.py
@@ -92,7 +92,7 @@ def main() -> None:
     parser.add_argument(
         "-t",
         "--template",
-        default="utils/module.yml.j2",
+        default="scripts/module.yml.j2",
         help="Path to the Jinja2 template file.",
     )
     parser.add_argument(


### PR DESCRIPTION
This was missed in the original commit that renamed the directory.