### PR TITLE
doc: Fix doxygen project name

### DIFF
--- a/doc/low_api_common.rst
+++ b/doc/low_api_common.rst
@@ -8,5 +8,5 @@ The common API is used for both normal operation and Radio Test mode.
 
 
 .. doxygengroup:: nrf_wifi_api_common
-   :project: hal_nordic
+   :project: nrf_wifi
    :members:

--- a/doc/low_api_radio_test.rst
+++ b/doc/low_api_radio_test.rst
@@ -11,5 +11,5 @@ The Radio Test mode is used for testing the RF performance of the nRF70 Series d
 | Source file: :file:`nrf_wifi/fw_if/umac_if/src/radio_test/fmac_api.c`
 
 .. doxygengroup:: nrf_wifi_api_radio_test
-   :project: hal_nordic
+   :project: nrf_wifi
    :members:

--- a/doc/low_api_wifi.rst
+++ b/doc/low_api_wifi.rst
@@ -7,5 +7,5 @@ The Wi-Fi mode is used for normal operation of the nRF70 Series device in, for e
 | Source file: :file:`nrf_wifi/fw_if/umac_if/src/default/fmac_api.c`
 
 .. doxygengroup:: nrf_wifi_api
-   :project: hal_nordic
+   :project: nrf_wifi
    :members:


### PR DESCRIPTION
Leftover from migration.