### PR TITLE
.gitignore: ignore binary blobs pulled by `west blobs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/zephyr/blobs


### PR DESCRIPTION
Add binary blobs to .gitignore, since they should not be committed and clutter up git status output.