### PR TITLE
nrf_wifi: Add support to read battery voltage

### DIFF
--- a/fw_if/umac_if/inc/radio_test/fmac_api.h
+++ b/fw_if/umac_if/inc/radio_test/fmac_api.h
@@ -161,7 +161,18 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_dpd(struct nrf_wifi_fmac_dev_ctx *
  */
 enum nrf_wifi_status nrf_wifi_rt_fmac_rf_get_temp(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);
 
-
+/**
+ * @brief Logs the battery voltage in milliVolts.
+ * @param fmac_dev_ctx Pointer to the UMAC IF context for a RPU WLAN device.
+ *
+ * This function is used to send a command to:
+ *	- The RPU firmware to acquire the battery voltage using
+ *	  the radio test mode.
+ *
+ * @retval NRF_WIFI_STATUS_SUCCESS On Success
+ * @retval NRF_WIFI_STATUS_FAIL On failure to execute command
+ */
+enum nrf_wifi_status nrf_wifi_rt_fmac_rf_get_bat_volt(struct nrf_wifi_fmac_dev_ctx* fmac_dev_ctx);
 
 /**
  * @brief Get RF RSSI status.

--- a/fw_if/umac_if/src/radio_test/fmac_event.c
+++ b/fw_if/umac_if/src/radio_test/fmac_event.c
@@ -60,6 +60,8 @@ static enum nrf_wifi_status umac_event_rt_rf_test_process(struct nrf_wifi_fmac_d
 	struct nrf_wifi_rf_get_xo_value rf_get_xo_value_params;
 	struct nrf_wifi_rt_fmac_dev_ctx *def_dev_ctx;
 	struct nrf_wifi_rf_test_capture_params rf_test_capture_params;
+	struct nrf_wifi_bat_volt_params bat_volt_params;
+	unsigned int bat_volt;
 
 	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
@@ -111,6 +113,20 @@ static enum nrf_wifi_status umac_event_rt_rf_test_process(struct nrf_wifi_fmac_d
 					       rf_test_get_temperature.temperature);
 		}
 		break;
+	case NRF_WIFI_RF_TEST_EVENT_GET_BAT_VOLT:
+		nrf_wifi_osal_mem_cpy(&bat_volt_params,
+				      (const unsigned char*) &rf_test_event->rf_test_info.rfevent[0],
+				      sizeof(bat_volt_params));
+		if (bat_volt_params.cmd_status) {
+			nrf_wifi_osal_log_err("Battery Volatge reading failed");
+		} else {
+			bat_volt = (VBAT_OFFSET_MILLIVOLT + 
+			(VBAT_SCALING_FACTOR * bat_volt_params.voltage));
+
+			nrf_wifi_osal_log_info("The battery voltage is = %d mV",
+						bat_volt);
+		}
+		break;		
 	case NRF_WIFI_RF_TEST_EVENT_RF_RSSI:
 		nrf_wifi_osal_mem_cpy(&rf_get_rf_rssi,
 				(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],

--- a/hw_if/hal/inc/radio_test/phy_rf_params.h
+++ b/hw_if/hal/inc/radio_test/phy_rf_params.h
@@ -21,6 +21,9 @@
 #define RX_CAPTURE_TIMEOUT_CONST 11
 #define CAPTURE_DURATION_IN_SEC 600
 
+#define VBAT_OFFSET_MILLIVOLT (2500)
+#define VBAT_SCALING_FACTOR (70)
+
 enum nrf_wifi_rf_test {
 	NRF_WIFI_RF_TEST_RX_ADC_CAP,
 	NRF_WIFI_RF_TEST_RX_STAT_PKT_CAP,
@@ -32,6 +35,7 @@ enum nrf_wifi_rf_test {
 	NRF_WIFI_RF_TEST_GET_TEMPERATURE,
 	NRF_WIFI_RF_TEST_XO_CALIB,
 	NRF_WIFI_RF_TEST_XO_TUNE,
+	NRF_WIFI_RF_TEST_GET_BAT_VOLT,
 	NRF_WIFI_RF_TEST_MAX,
 };
 
@@ -45,6 +49,8 @@ enum nrf_wifi_rf_test_event {
 	NRF_WIFI_RF_TEST_EVENT_SLEEP,
 	NRF_WIFI_RF_TEST_EVENT_TEMP_MEAS,
 	NRF_WIFI_RF_TEST_EVENT_XO_CALIB,
+	NRF_WIFI_RF_TEST_EVENT_XO_TUNE,
+	NRF_WIFI_RF_TEST_EVENT_GET_BAT_VOLT,
 	NRF_WIFI_RF_TEST_EVENT_MAX,
 };
 
@@ -130,6 +136,17 @@ struct nrf_wifi_temperature_params {
 	 * 1: Reading failed
 	 */
 	unsigned int readTemperatureStatus;
+} __NRF_WIFI_PKD;
+
+struct nrf_wifi_bat_volt_params {
+	unsigned char test;
+	/** Measured battery voltage in milliVolts. */
+	unsigned char voltage;
+	/** Status of the voltage measurement command.
+	 * 0: Reading successful
+	 * 1: Reading failed
+	 */
+	unsigned int cmd_status;
 } __NRF_WIFI_PKD;
 
 struct nrf_wifi_rf_get_rf_rssi {


### PR DESCRIPTION
This commit introduces support for reading and
displaying the battery voltage.