### PR TITLE
Enable build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,57 @@ target_compile_definitions(
   WIFI_NRF70_LOG_LEVEL=${CONFIG_WIFI_NRF70_LOG_LEVEL}
 )
 
+target_compile_options(nrf-wifi-osal PUBLIC
+    -Wall                     # All warnings
+    -Wextra                   # Extra warnings
+    -Werror                   # Warnings as errors
+    -Wformat=2                # Format string checks
+    -Wformat-security         # Security issues with format strings
+    -Wnull-dereference        # Null pointer dereferences
+    -Wstack-protector         # Stack protection
+    -fstack-protector-strong  # Strong stack protection
+    -Warray-bounds            # Array bounds checking
+    -Wstringop-overflow       # String operation overflow
+    -Wconversion              # Implicit conversions
+    -Wsign-conversion         # Sign conversions
+    -Wmissing-include-dirs    # Missing include directories
+    -Wcast-align              # Pointer cast alignment
+    -Wcast-qual               # Pointer cast dropping qualifiers
+    -Wdiscarded-qualifiers    # Discarded qualifiers
+    -Wduplicated-branches     # Duplicated branches
+    -Wduplicated-cond         # Duplicated conditions
+    -Wlogical-op              # Suspicious logical operators
+    -Wnull-dereference        # Null pointer dereferences
+    -Wjump-misses-init        # Goto skipping variable initialization
+    -Wunused-parameter        # Unused parameters
+    -Wshift-overflow=2        # Shift overflows
+    -Wmissing-prototypes      # Missing function prototypes
+    -Wredundant-decls         # Redundant declarations
+    -Wtype-limits             # Type limits
+    -Wshadow                  # Shadowed variables
+    -Wstrict-prototypes       # Strict prototypes
+    -Wundef                   # Undefined macros
+    -Wuninitialized           # Uninitialized variables
+    -Wpointer-arith           # Pointer arithmetic
+    -Wbad-function-cast       # Bad function casts
+    -Wstrict-overflow         # Strict overflow
+    -Winline                  # Inlining issues
+    -Wnested-externs          # Nested externs
+    -Wold-style-definition    # Old-style definitions
+    -Wmissing-declarations    # Missing declarations
+    -Wmissing-noreturn        # Missing noreturn
+    -Wdisabled-optimization   # Disabled optimizations
+    -Wfloat-equal             # Floating point equality
+    -Winit-self               # Initialization to self
+    -Wswitch-default          # Missing switch default
+    -Wswitch-enum             # Missing switch enum
+    -Wunsafe-loop-optimizations # Unsafe loop optimizations
+    -Wlogical-not-parentheses # Logical not parentheses
+    -Wstrict-aliasing         # Strict aliasing
+    -Wvariadic-macros         # Variadic macros
+    -Wvolatile-register-var   # Volatile register variables
+)
+
 target_include_directories(
   nrf-wifi-osal
   PUBLIC


### PR DESCRIPTION
Enable typical warnings to catch issues at build time itself.