### PR TITLE
Fix FPU configuration for NRF91 Series

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,13 @@ add_library(nrf-wifi-osal STATIC "")
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
   # Set the CPU architecture to armv8-m.main (Cortex-M33), default is armv4t for Zephyr ARM targets
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -mcpu=cortex-m33 -mthumb")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -mcpu=cortex-m33 -mthumb")
+  if(CONFIG_SOC_SERIES_NRF91X)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -mcpu=cortex-m33 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -mcpu=cortex-m33 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16")
+  else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -mcpu=cortex-m33 -mthumb")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -mcpu=cortex-m33 -mthumb")
+  endif()
 endif()
 
 set(NRF_WIFI_DIR ${ZEPHYR_NRF_WIFI_MODULE_DIR})


### PR DESCRIPTION
nRF9151 needs FPU to be enabled else will causing linking issues when this libray is linked with the Zephyr native driver.

"error: zephyr/zephyr_pre0.elf uses VFP register arguments, modules/nrf_wifi/os/nrf_wifi_osal/libnrf-wifi-osal.a(rx.c.obj) does not"