### PR TITLE
nrf_wifi : Update Wi-Fi FW blobs and stats folder

### DIFF
--- a/fw_if/umac_if/inc/fw/patch_info.h
+++ b/fw_if/umac_if/inc/fw/patch_info.h
@@ -61,8 +61,8 @@ struct nrf70_fw_image_info {
 
 #define RPU_FAMILY         (1)
 #define RPU_MAJOR_VERSION   (2)
-#define RPU_MINOR_VERSION   (13)
-#define RPU_PATCH_VERSION   (23)
+#define RPU_MINOR_VERSION   (14)
+#define RPU_PATCH_VERSION   (0)
 
 /**
  * @}

--- a/fw_if/umac_if/inc/fw/stats/default/rpu_umac_stats.h
+++ b/fw_if/umac_if/inc/fw/stats/default/rpu_umac_stats.h
@@ -26,9 +26,10 @@ struct stat rpu_umac_stats[] = {
 	{"tx_cmd", 0x8008bd9c },
 	{"tx_cmds_currently_in_use", 0x8008bdb0 },
 	{"tx_done_events_send_to_host", 0x8008bdb4 },
-	{"tx_cmd_to_lmactx_dones_from_lmac", 0x8008bdec },
+	{"tx_cmd_to_lmac", 0x8008bdec },
 	{"tx_dones_from_lmac", 0x8008bdf0 },
 	{"total_cmds_to_lmac", 0x8008bdf4 },
+	{"cmd_processing", 0x80132000 },
 	{"lmac_events", 0x80080388 },
 	{"rx_events", 0x8008038c },
 	{"current_refill_gap", 0x8008039c },
@@ -36,9 +37,6 @@ struct stat rpu_umac_stats[] = {
 	{"host_consumed_pkts", 0x800803ac },
 	{"rx_mbox_post", 0x800803b0 },
 	{"rx_mbox_receive", 0x800803b4 },
-	{"null_skb_pointer_from_lmac", 0x80080415 },
-	{"cmd_init", 0x8008bec4 },
-	{"event_init_done", 0x8008bec5 },
 	{"cmd_trigger_scan", 0x8008bedc },
 	{"event_scan_done", 0x8008bee0 },
 	{"umac_scan_req", 0x8008bee8 },
@@ -50,6 +48,9 @@ struct stat rpu_umac_stats[] = {
 	{"event_node_alloc_fail", 0x8008be3c },
 	{"hpqm_event_pop_fail", 0x8008be40 },
 	{"total_events_to_host", 0x8008be48 },
+	{"cmd_init", 0x8008bec4 },
+	{"event_init_done", 0x800972e8 },
+	{"null_skb_pointer_from_lmac", 0x800972e4 },
 };
  
 #endif /* __RPU_UMAC_STATS_H__ */

--- a/fw_if/umac_if/inc/fw/stats/offloaded_raw_tx/rpu_lmac_phy_stats.h
+++ b/fw_if/umac_if/inc/fw/stats/offloaded_raw_tx/rpu_lmac_phy_stats.h
@@ -82,9 +82,9 @@ struct rpu_phy_stats[] = {
 * @brief offload raw tx debug variables.
 */
 struct rpu_offload_raw_tx_stats[] = {
-	{"offLoad_raw_tx_state", 0x800473c4 },
-	{"offload_raw_tx_cnt", 0x800473a8 },
-	{"offload_raw_tx_complete_cnt", 0x800473ac },
+	{"offLoad_raw_tx_state", 0x800473b4 },
+	{"offload_raw_tx_cnt", 0x80047398 },
+	{"offload_raw_tx_complete_cnt", 0x8004739c },
 	{"offload_raw_tx_stats.warm_boot_cnt", 0x8004116c },
 };
  

--- a/fw_if/umac_if/inc/fw/stats/offloaded_raw_tx/rpu_umac_stats.h
+++ b/fw_if/umac_if/inc/fw/stats/offloaded_raw_tx/rpu_umac_stats.h
@@ -26,9 +26,10 @@ struct stat rpu_umac_stats[] = {
 	{"tx_cmd", 0x8008bd9c },
 	{"tx_cmds_currently_in_use", 0x8008bdb0 },
 	{"tx_done_events_send_to_host", 0x8008bdb4 },
-	{"tx_cmd_to_lmactx_dones_from_lmac", 0x8008bdec },
+	{"tx_cmd_to_lmac", 0x8008bdec },
 	{"tx_dones_from_lmac", 0x8008bdf0 },
 	{"total_cmds_to_lmac", 0x8008bdf4 },
+	{"cmd_processing", 0x80132000 },
 	{"lmac_events", 0x80080388 },
 	{"rx_events", 0x8008038c },
 	{"current_refill_gap", 0x8008039c },
@@ -36,9 +37,6 @@ struct stat rpu_umac_stats[] = {
 	{"host_consumed_pkts", 0x800803ac },
 	{"rx_mbox_post", 0x800803b0 },
 	{"rx_mbox_receive", 0x800803b4 },
-	{"null_skb_pointer_from_lmac", 0x80080415 },
-	{"cmd_init", 0x8008bec4 },
-	{"event_init_done", 0x8008bec5 },
 	{"cmd_trigger_scan", 0x8008bedc },
 	{"event_scan_done", 0x8008bee0 },
 	{"umac_scan_req", 0x8008bee8 },
@@ -50,16 +48,19 @@ struct stat rpu_umac_stats[] = {
 	{"event_node_alloc_fail", 0x8008be3c },
 	{"hpqm_event_pop_fail", 0x8008be40 },
 	{"total_events_to_host", 0x8008be48 },
+	{"cmd_init", 0x8008bec4 },
+	{"event_init_done", 0x8008e070 },
+	{"null_skb_pointer_from_lmac", 0x8008e06c },
 };
  
 /**
 * @brief offload raw tx debug variables.
 */
 struct rpu_offload_raw_tx_stats[] = {
-	{"offload_raw_tx_state", 0x8008e050 },
-	{"offload_raw_tx_cnt", 0x8008e054 },
-	{"offload_raw_tx_complete_cnt", 0x8008e058 },
-	{"warm_boot_cnt", 0x8008e05c },
+	{"offload_raw_tx_state", 0x8008e0e4 },
+	{"offload_raw_tx_cnt", 0x8008e0e8 },
+	{"offload_raw_tx_complete_cnt", 0x8008e0ec },
+	{"warm_boot_cnt", 0x8008e0f0 },
 };
  
 #endif /* __RPU_UMAC_STATS_H__ */

--- a/fw_if/umac_if/inc/fw/stats/radio_test/rpu_umac_stats.h
+++ b/fw_if/umac_if/inc/fw/stats/radio_test/rpu_umac_stats.h
@@ -26,9 +26,10 @@ struct stat rpu_umac_stats[] = {
 	{"tx_cmd", 0x8008bd9c },
 	{"tx_cmds_currently_in_use", 0x8008bdb0 },
 	{"tx_done_events_send_to_host", 0x8008bdb4 },
-	{"tx_cmd_to_lmactx_dones_from_lmac", 0x8008bdec },
+	{"tx_cmd_to_lmac", 0x8008bdec },
 	{"tx_dones_from_lmac", 0x8008bdf0 },
 	{"total_cmds_to_lmac", 0x8008bdf4 },
+	{"cmd_processing", 0x80132000 },
 	{"lmac_events", 0x80080388 },
 	{"rx_events", 0x8008038c },
 	{"current_refill_gap", 0x8008039c },
@@ -36,9 +37,6 @@ struct stat rpu_umac_stats[] = {
 	{"host_consumed_pkts", 0x800803ac },
 	{"rx_mbox_post", 0x800803b0 },
 	{"rx_mbox_receive", 0x800803b4 },
-	{"null_skb_pointer_from_lmac", 0x80080415 },
-	{"cmd_init", 0x8008bec4 },
-	{"event_init_done", 0x8008bec5 },
 	{"cmd_trigger_scan", 0x8008bedc },
 	{"event_scan_done", 0x8008bee0 },
 	{"umac_scan_req", 0x8008bee8 },
@@ -50,6 +48,8 @@ struct stat rpu_umac_stats[] = {
 	{"event_node_alloc_fail", 0x8008be3c },
 	{"hpqm_event_pop_fail", 0x8008be40 },
 	{"total_events_to_host", 0x8008be48 },
+	{"cmd_init", 0x8008bec4 },
+	{"event_init_done", 0x80090e24 },
 };
  
 #endif /* __RPU_UMAC_STATS_H__ */

--- a/fw_if/umac_if/inc/fw/stats/scan_only/rpu_umac_stats.h
+++ b/fw_if/umac_if/inc/fw/stats/scan_only/rpu_umac_stats.h
@@ -26,9 +26,10 @@ struct stat rpu_umac_stats[] = {
 	{"tx_cmd", 0x8008bd9c },
 	{"tx_cmds_currently_in_use", 0x8008bdb0 },
 	{"tx_done_events_send_to_host", 0x8008bdb4 },
-	{"tx_cmd_to_lmactx_dones_from_lmac", 0x8008bdec },
+	{"tx_cmd_to_lmac", 0x8008bdec },
 	{"tx_dones_from_lmac", 0x8008bdf0 },
 	{"total_cmds_to_lmac", 0x8008bdf4 },
+	{"cmd_processing", 0x80132000 },
 	{"lmac_events", 0x80080388 },
 	{"rx_events", 0x8008038c },
 	{"current_refill_gap", 0x8008039c },
@@ -36,9 +37,6 @@ struct stat rpu_umac_stats[] = {
 	{"host_consumed_pkts", 0x800803ac },
 	{"rx_mbox_post", 0x800803b0 },
 	{"rx_mbox_receive", 0x800803b4 },
-	{"null_skb_pointer_from_lmac", 0x80080415 },
-	{"cmd_init", 0x8008bec4 },
-	{"event_init_done", 0x8008bec5 },
 	{"cmd_trigger_scan", 0x8008bedc },
 	{"event_scan_done", 0x8008bee0 },
 	{"umac_scan_req", 0x8008bee8 },
@@ -50,6 +48,9 @@ struct stat rpu_umac_stats[] = {
 	{"event_node_alloc_fail", 0x8008be3c },
 	{"hpqm_event_pop_fail", 0x8008be40 },
 	{"total_events_to_host", 0x8008be48 },
+	{"cmd_init", 0x8008bec4 },
+	{"event_init_done", 0x80090508 },
+	{"null_skb_pointer_from_lmac", 0x80090504 },
 };
  
 #endif /* __RPU_UMAC_STATS_H__ */

--- a/fw_if/umac_if/inc/fw/stats/system_with_raw/rpu_umac_stats.h
+++ b/fw_if/umac_if/inc/fw/stats/system_with_raw/rpu_umac_stats.h
@@ -26,9 +26,10 @@ struct stat rpu_umac_stats[] = {
 	{"tx_cmd", 0x8008bd9c },
 	{"tx_cmds_currently_in_use", 0x8008bdb0 },
 	{"tx_done_events_send_to_host", 0x8008bdb4 },
-	{"tx_cmd_to_lmactx_dones_from_lmac", 0x8008bdec },
+	{"tx_cmd_to_lmac", 0x8008bdec },
 	{"tx_dones_from_lmac", 0x8008bdf0 },
 	{"total_cmds_to_lmac", 0x8008bdf4 },
+	{"cmd_processing", 0x80132000 },
 	{"lmac_events", 0x80080388 },
 	{"rx_events", 0x8008038c },
 	{"current_refill_gap", 0x8008039c },
@@ -36,9 +37,6 @@ struct stat rpu_umac_stats[] = {
 	{"host_consumed_pkts", 0x800803ac },
 	{"rx_mbox_post", 0x800803b0 },
 	{"rx_mbox_receive", 0x800803b4 },
-	{"null_skb_pointer_from_lmac", 0x80080415 },
-	{"cmd_init", 0x8008bec4 },
-	{"event_init_done", 0x8008bec5 },
 	{"cmd_trigger_scan", 0x8008bedc },
 	{"event_scan_done", 0x8008bee0 },
 	{"umac_scan_req", 0x8008bee8 },
@@ -50,22 +48,25 @@ struct stat rpu_umac_stats[] = {
 	{"event_node_alloc_fail", 0x8008be3c },
 	{"hpqm_event_pop_fail", 0x8008be40 },
 	{"total_events_to_host", 0x8008be48 },
+	{"cmd_init", 0x8008bec4 },
+	{"event_init_done", 0x80098120 },
+	{"null_skb_pointer_from_lmac", 0x8009811c },
 };
  
 /**
 * @brief Raw TX RX debug variables.
 */
 struct stat rpu_rawtx_stats[] = {
-	{"raw_tx_from_host", 0x80098160 },
-	{"raw_tx_to_lmac", 0x80098164 },
-	{"raw_tx_dones_from_lmac", 0x80098168 },
-	{"raw_tx_dones_to_host", 0x8009816c },
-	{"total_rx_pkts_from_lmac", 0x80098170 },
-	{"raw_tx_dones_from_lmac", 0x80098168 },
-	{"total_raw_rx_pkts_from_lmac", 0x80098174 },
-	{"valid_raw_rx_pkts_from_lmac", 0x80098178 },
-	{"raw_tx_dones_from_lmac", 0x80098168 },
-	{"raw_rx_pkts_to_host", 0x8009817c },
+	{"raw_tx_from_host", 0x800981e8 },
+	{"raw_tx_to_lmac", 0x800981ec },
+	{"raw_tx_dones_from_lmac", 0x800981f0 },
+	{"raw_tx_dones_to_host", 0x800981f4 },
+	{"total_rx_pkts_from_lmac", 0x800981f8 },
+	{"raw_tx_dones_from_lmac", 0x800981f0 },
+	{"total_raw_rx_pkts_from_lmac", 0x800981fc },
+	{"valid_raw_rx_pkts_from_lmac", 0x80098200 },
+	{"raw_tx_dones_from_lmac", 0x800981f0 },
+	{"raw_rx_pkts_to_host", 0x80098204 },
 };
  
 #endif /* __RPU_UMAC_STATS_H__ */

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -6,46 +6,46 @@ build:
 blobs:
 
     - path: wifi_fw_bins/default/nrf70.bin
-      sha256: f5f89103e3e54ad8ab39249743f1d84404689d81f67a7960490821f96cfdb164
+      sha256: b7706c3a7833e4fb0a3a87d08783aaccc4bb8fb1d2693d607562c5203cf0ea78
       type: img
       version: '1.0.0'
       license-path: ./LICENSE.txt
-      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/bin/zephyr/default/nrf70.bin
+      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/bin/zephyr/default/nrf70.bin
       description: nRF70 Wi-Fi firmware for default mode
-      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/doc
+      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/doc
 
     - path: wifi_fw_bins/scan_only/nrf70.bin
-      sha256: c85cbbcf9e24581e25b3c40f047cb62d99da42b812097eeff0c8e354ba6126f7
+      sha256: 22951797b9625de0ee409b3a49dc384aa0b9642e14585d8da2f0775012bb302d
       type: img
       version: '1.0.0'
       license-path: ./LICENSE.txt
-      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/bin/zephyr/scan_only/nrf70.bin
+      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/bin/zephyr/scan_only/nrf70.bin
       description: nRF70 Wi-Fi firmware for scan_only mode
-      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/doc
+      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/doc
 
     - path: wifi_fw_bins/radio_test/nrf70.bin
-      sha256: 9bce0c40ab0ad291f06be02923a84632338370a438c73e035b4182579add9da3
+      sha256: fda85d8b7d4379736202f789b25d0ee37d083df9a3929d653bf6a1efd01256ba
       type: img
       version: '1.0.0'
       license-path: ./LICENSE.txt
-      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/bin/zephyr/radio_test/nrf70.bin
+      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/bin/zephyr/radio_test/nrf70.bin
       description: nRF70 Wi-Fi firmware for radio_test mode
-      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/doc
+      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/doc
 
     - path: wifi_fw_bins/system_with_raw/nrf70.bin
-      sha256: c3d6bf02fd163c996bd5ebc026ed631681c427b30484e145c197fc347c166c49
+      sha256: 87cd504cbfbdf7a078dd3b39d6f4c3e0bb217e6785295a72f5723441eb6cdc41
       type: img
       version: '1.0.0'
       license-path: ./LICENSE.txt
-      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/bin/zephyr/system_with_raw/nrf70.bin
+      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/bin/zephyr/system_with_raw/nrf70.bin
       description: nRF70 Wi-Fi firmware for system_with_raw mode
-      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/doc
+      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/doc
 
     - path: wifi_fw_bins/offloaded_raw_tx/nrf70.bin
-      sha256: 065eaaae56119c498cfba8a35dff9e8a8c3be875ad9c8f4656becef0f5f48819
+      sha256: d75da2aa44659cec36def2a128a78e5ec70770e6b407d0ff925b1aa5f7be7cf6
       type: img
       version: '1.0.0'
       license-path: ./LICENSE.txt
-      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/bin/zephyr/offloaded_raw_tx/nrf70.bin
+      url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/bin/zephyr/offloaded_raw_tx/nrf70.bin
       description: nRF70 Wi-Fi firmware for offloaded_raw_tx mode
-      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/0286bed78f1945eb6d03045380869df972ea2c3f/nrf_wifi/doc
+      doc-url: https://github.com/nrfconnect/sdk-nrfxlib/raw/335acc3ea3a7929cea09a640203103a16d964a6f/nrf_wifi/doc


### PR DESCRIPTION
Update firmware binaries and RPU debug stats headers in the stats folder with updated rpu path version for 3.0.0 release.