### PR TITLE
treewide: remove trailing log newlines

### DIFF
--- a/bus_if/bus/pcie/src/pcie.c
+++ b/bus_if/bus/pcie/src/pcie.c
@@ -43,7 +43,7 @@ void *nrf_wifi_bus_pcie_dev_add(void *bus_priv,
 	if (!pcie_dev_ctx)
 	{
 		nrf_wifi_osal_log_err(
-			"%s: Unable to allocate pcie_dev_ctx\n", __func__);
+			"%s: Unable to allocate pcie_dev_ctx", __func__);
 		goto out;
 	}
 
@@ -57,7 +57,7 @@ void *nrf_wifi_bus_pcie_dev_add(void *bus_priv,
 	if (!pcie_dev_ctx->os_pcie_dev_ctx)
 	{
 		nrf_wifi_osal_log_err(
-			"%s: nrf_wifi_osal_bus_pcie_dev_add failed\n", __func__);
+			"%s: nrf_wifi_osal_bus_pcie_dev_add failed", __func__);
 
 		nrf_wifi_osal_mem_free(
 			pcie_dev_ctx);
@@ -94,7 +94,7 @@ void *nrf_wifi_bus_pcie_dev_add(void *bus_priv,
 	if (status != NRF_WIFI_STATUS_SUCCESS)
 	{
 		nrf_wifi_osal_log_err(
-			"%s: Unable to register PCIe interrupt to the OS\n",
+			"%s: Unable to register PCIe interrupt to the OS",
 			__func__);
 
 		nrf_wifi_osal_iomem_unmap(
@@ -147,7 +147,7 @@ enum nrf_wifi_status nrf_wifi_bus_pcie_dev_init(void *bus_dev_ctx)
 	if (status != NRF_WIFI_STATUS_SUCCESS)
 	{
 		nrf_wifi_osal_log_err(
-			"%s: nrf_wifi_osal_pcie_dev_init failed\n", __func__);
+			"%s: nrf_wifi_osal_pcie_dev_init failed", __func__);
 
 		goto out;
 	}
@@ -176,7 +176,7 @@ void *nrf_wifi_bus_pcie_init(void *params,
 	if (!pcie_priv)
 	{
 		nrf_wifi_osal_log_err(
-			"%s: Unable to allocate memory for pcie_priv\n",
+			"%s: Unable to allocate memory for pcie_priv",
 			__func__);
 		goto out;
 	}
@@ -198,7 +198,7 @@ void *nrf_wifi_bus_pcie_init(void *params,
 	if (!pcie_priv->os_pcie_priv)
 	{
 		nrf_wifi_osal_log_err(
-			"%s: Unable to register PCIe driver\n",
+			"%s: Unable to register PCIe driver",
 			__func__);
 
 		nrf_wifi_osal_mem_free(
@@ -385,7 +385,7 @@ unsigned long nrf_wifi_bus_pcie_dma_unmap(void *dev_ctx,
 #endif
 	if (status != NRF_WIFI_STATUS_SUCCESS)
 		nrf_wifi_osal_log_err(
-			"%s: pal_rpu_addr_offset_get failed\n", __func__);
+			"%s: pal_rpu_addr_offset_get failed", __func__);
 #endif /* OFFLINE_MODE */
 
 	return virt_addr;

--- a/fw_if/umac_if/src/common/fmac_api_common.c
+++ b/fw_if/umac_if/src/common/fmac_api_common.c
@@ -239,7 +239,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_reset(struct nrf_wifi_fmac_dev_ctx *fmac_d
 						 wifi_proc[i].type);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err("%s: %s processor reset failed\n",
+			nrf_wifi_osal_log_err("%s: %s processor reset failed",
 					      __func__, wifi_proc[i].name);
 			return NRF_WIFI_STATUS_FAIL;
 		}
@@ -259,7 +259,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_boot(struct nrf_wifi_fmac_dev_ctx *fmac_de
 						    wifi_proc[i].is_patch_present);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err("%s: %s processor ROM boot failed\n",
+			nrf_wifi_osal_log_err("%s: %s processor ROM boot failed",
 					      __func__, wifi_proc[i].name);
 			return NRF_WIFI_STATUS_FAIL;
 		}
@@ -268,7 +268,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_boot(struct nrf_wifi_fmac_dev_ctx *fmac_de
 						  wifi_proc[i].type);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err("%s: %s processor ROM boot check failed\n",
+			nrf_wifi_osal_log_err("%s: %s processor ROM boot check failed",
 					      __func__, wifi_proc[i].name);
 			return NRF_WIFI_STATUS_FAIL;
 		}
@@ -296,7 +296,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	status = nrf_wifi_fmac_fw_reset(fmac_dev_ctx);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err("%s: FW reset failed\n",
+		nrf_wifi_osal_log_err("%s: FW reset failed",
 				      __func__);
 		goto out;
 	}
@@ -312,11 +312,11 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 						    fmac_fw->umac_patch_sec.size);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err("%s: UMAC patch load failed\n",
+			nrf_wifi_osal_log_err("%s: UMAC patch load failed",
 					      __func__);
 			goto out;
 		} else {
-			nrf_wifi_osal_log_dbg("%s: UMAC patches loaded\n",
+			nrf_wifi_osal_log_dbg("%s: UMAC patches loaded",
 					      __func__);
 		}
 	} else {
@@ -334,11 +334,11 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 						    fmac_fw->lmac_patch_sec.size);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err("%s: LMAC patch load failed\n",
+			nrf_wifi_osal_log_err("%s: LMAC patch load failed",
 					      __func__);
 			goto out;
 		} else {
-			nrf_wifi_osal_log_dbg("%s: LMAC patches loaded\n",
+			nrf_wifi_osal_log_dbg("%s: LMAC patches loaded",
 					      __func__);
 		}
 	} else {
@@ -347,7 +347,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	status = nrf_wifi_fmac_fw_boot(fmac_dev_ctx);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err("%s: FW boot failed\n",
+		nrf_wifi_osal_log_err("%s: FW boot failed",
 				      __func__);
 		goto out;
 	}

--- a/fw_if/umac_if/src/offload_raw_tx/fmac_cmd.c
+++ b/fw_if/umac_if/src/offload_raw_tx/fmac_cmd.c
@@ -83,12 +83,12 @@ enum nrf_wifi_status umac_cmd_off_raw_tx_init(struct nrf_wifi_fmac_dev_ctx *fmac
 
 #ifdef NRF_WIFI_MGMT_BUFF_OFFLOAD
 	umac_cmd_data->mgmt_buff_offload =  1;
-	nrf_wifi_osal_log_info("Management buffer offload enabled\n");
+	nrf_wifi_osal_log_info("Management buffer offload enabled");
 #endif /* NRF_WIFI_MGMT_BUFF_OFFLOAD */
 #ifdef NRF_WIFI_FEAT_KEEPALIVE
 	umac_cmd_data->keep_alive_enable = KEEP_ALIVE_ENABLED;
 	umac_cmd_data->keep_alive_period = NRF_WIFI_KEEPALIVE_PERIOD_S;
-	nrf_wifi_osal_log_dbg("Keepalive enabled with period %d\n",
+	nrf_wifi_osal_log_dbg("Keepalive enabled with period %d",
 				   umac_cmd_data->keepalive_period);
 #endif /* NRF_WIFI_FEAT_KEEPALIVE */
 

--- a/fw_if/umac_if/src/offload_raw_tx/fmac_event.c
+++ b/fw_if/umac_if/src/offload_raw_tx/fmac_event.c
@@ -123,7 +123,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 	}
 
 #ifdef NRF_WIFI_CMD_EVENT_LOG
-	nrf_wifi_osal_log_info("%s: Event %d received from UMAC\n",
+	nrf_wifi_osal_log_info("%s: Event %d received from UMAC",
 			      __func__,
 			      event_num);
 #else
@@ -184,7 +184,7 @@ enum nrf_wifi_status nrf_wifi_off_raw_tx_fmac_event_callback(void *mac_dev_ctx,
 	umac_msg_type = umac_hdr->cmd_evnt;
 
 #ifdef NRF_WIFI_CMD_EVENT_LOG
-	nrf_wifi_osal_log_info("%s: Event type %d recd\n",
+	nrf_wifi_osal_log_info("%s: Event type %d recd",
 			      __func__,
 			      rpu_msg->type);
 #else

--- a/fw_if/umac_if/src/radio_test/fmac_cmd.c
+++ b/fw_if/umac_if/src/radio_test/fmac_cmd.c
@@ -83,12 +83,12 @@ enum nrf_wifi_status umac_cmd_rt_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx
 
 #ifdef NRF_WIFI_MGMT_BUFF_OFFLOAD
 	umac_cmd_data->mgmt_buff_offload =  1;
-	nrf_wifi_osal_log_info("Management buffer offload enabled\n");
+	nrf_wifi_osal_log_info("Management buffer offload enabled");
 #endif /* NRF_WIFI_MGMT_BUFF_OFFLOAD */
 #ifdef NRF_WIFI_FEAT_KEEPALIVE
 	umac_cmd_data->keep_alive_enable = KEEP_ALIVE_ENABLED;
 	umac_cmd_data->keep_alive_period = NRF_WIFI_KEEPALIVE_PERIOD_S;
-	nrf_wifi_osal_log_dbg("Keepalive enabled with period %d\n",
+	nrf_wifi_osal_log_dbg("Keepalive enabled with period %d",
 				   umac_cmd_data->keepalive_period);
 #endif /* NRF_WIFI_FEAT_KEEPALIVE */
 

--- a/fw_if/umac_if/src/radio_test/fmac_event.c
+++ b/fw_if/umac_if/src/radio_test/fmac_event.c
@@ -120,13 +120,13 @@ static enum nrf_wifi_status umac_event_rt_rf_test_process(struct nrf_wifi_fmac_d
 		if (bat_volt_params.cmd_status) {
 			nrf_wifi_osal_log_err("Battery Volatge reading failed");
 		} else {
-			bat_volt = (VBAT_OFFSET_MILLIVOLT + 
+			bat_volt = (VBAT_OFFSET_MILLIVOLT +
 			(VBAT_SCALING_FACTOR * bat_volt_params.voltage));
 
 			nrf_wifi_osal_log_info("The battery voltage is = %d mV",
 						bat_volt);
 		}
-		break;		
+		break;
 	case NRF_WIFI_RF_TEST_EVENT_RF_RSSI:
 		nrf_wifi_osal_mem_cpy(&rf_get_rf_rssi,
 				(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
@@ -243,7 +243,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 	}
 
 #ifdef NRF_WIFI_CMD_EVENT_LOG
-	nrf_wifi_osal_log_info("%s: Event %d received from UMAC\n",
+	nrf_wifi_osal_log_info("%s: Event %d received from UMAC",
 			      __func__,
 			      event_num);
 #else
@@ -320,7 +320,7 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_event_callback(void *mac_dev_ctx,
 	umac_msg_type = umac_hdr->cmd_evnt;
 
 #ifdef NRF_WIFI_CMD_EVENT_LOG
-	nrf_wifi_osal_log_info("%s: Event type %d recd\n",
+	nrf_wifi_osal_log_info("%s: Event type %d recd",
 			      __func__,
 			      rpu_msg->type);
 #else
@@ -352,4 +352,3 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_event_callback(void *mac_dev_ctx,
 out:
 	return status;
 }
-

--- a/fw_if/umac_if/src/system/fmac_api.c
+++ b/fw_if/umac_if/src/system/fmac_api.c
@@ -3322,7 +3322,7 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_set_ps_exit_strategy(void *dev_ctx,
 	set_ps_exit_strategy_cmd = nrf_wifi_osal_mem_zalloc(sizeof(*set_ps_exit_strategy_cmd));
 
 	if (!set_ps_exit_strategy_cmd) {
-		nrf_wifi_osal_log_err("%s: Unable to allocate memory\n", __func__);
+		nrf_wifi_osal_log_err("%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 
@@ -3771,7 +3771,7 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_set_packet_filter(void *dev_ctx, unsigned
 	int len = 0;
 
 	if (!fmac_dev_ctx) {
-		nrf_wifi_osal_log_err("%s: Invalid parameters\n",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -3787,7 +3787,7 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_set_packet_filter(void *dev_ctx, unsigned
 				  NRF_WIFI_HOST_RPU_MSG_TYPE_SYSTEM,
 				  len);
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed\n",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}

--- a/fw_if/umac_if/src/system/fmac_cmd.c
+++ b/fw_if/umac_if/src/system/fmac_cmd.c
@@ -89,12 +89,12 @@ enum nrf_wifi_status umac_cmd_sys_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 
 #ifdef NRF_WIFI_MGMT_BUFF_OFFLOAD
 	umac_cmd_data->mgmt_buff_offload =  1;
-	nrf_wifi_osal_log_info("Management buffer offload enabled\n");
+	nrf_wifi_osal_log_info("Management buffer offload enabled");
 #endif /* NRF_WIFI_MGMT_BUFF_OFFLOAD */
 #ifdef NRF_WIFI_FEAT_KEEPALIVE
 	umac_cmd_data->keep_alive_enable = KEEP_ALIVE_ENABLED;
 	umac_cmd_data->keep_alive_period = NRF_WIFI_KEEPALIVE_PERIOD_S;
-	nrf_wifi_osal_log_dbg("Keepalive enabled with period %d\n",
+	nrf_wifi_osal_log_dbg("Keepalive enabled with period %d",
 				   umac_cmd_data->keepalive_period);
 #endif /* NRF_WIFI_FEAT_KEEPALIVE */
 

--- a/fw_if/umac_if/src/system/fmac_event.c
+++ b/fw_if/umac_if/src/system/fmac_event.c
@@ -304,7 +304,7 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	event = ((struct nrf_wifi_umac_head *)umac_head)->cmd;
 
 #ifdef NRF_WIFI_CMD_EVENT_LOG
-	nrf_wifi_osal_log_info("%s: Event %d received from UMAC\n",
+	nrf_wifi_osal_log_info("%s: Event %d received from UMAC",
 			      __func__,
 			      event);
 #else
@@ -551,7 +551,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 	}
 
 #ifdef NRF_WIFI_CMD_EVENT_LOG
-	nrf_wifi_osal_log_info("%s: Event %d received from UMAC\n",
+	nrf_wifi_osal_log_info("%s: Event %d received from UMAC",
 			      __func__,
 			      event_num);
 #else
@@ -922,7 +922,7 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_event_callback(void *mac_dev_ctx,
 	umac_msg_type = umac_hdr->cmd_evnt;
 
 #ifdef NRF_WIFI_CMD_EVENT_LOG
-	nrf_wifi_osal_log_info("%s: Event type %d recd\n",
+	nrf_wifi_osal_log_info("%s: Event type %d recd",
 			      __func__,
 			      rpu_msg->type);
 #else

--- a/fw_if/umac_if/src/system/tx.c
+++ b/fw_if/umac_if/src/system/tx.c
@@ -781,7 +781,7 @@ enum nrf_wifi_status rawtx_cmd_prepare(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 
 	txq_len = nrf_wifi_utils_list_len(txq);
 	if (txq_len == 0) {
-		nrf_wifi_osal_log_err("%s: txq_len = %d\n",
+		nrf_wifi_osal_log_err("%s: txq_len = %d",
 				      __func__,
 				      txq_len);
 		goto err;
@@ -1906,7 +1906,7 @@ enum nrf_wifi_status nrf_wifi_fmac_start_rawpkt_xmit(void *dev_ctx,
 				     ac,
 				     peer_id);
 	if (tx_status == NRF_WIFI_FMAC_TX_STATUS_FAIL) {
-		nrf_wifi_osal_log_dbg("%s: Failed to send packet\n",
+		nrf_wifi_osal_log_dbg("%s: Failed to send packet",
 				      __func__);
 		/** Increment failure count */
 		sys_dev_ctx->raw_pkt_stats.raw_pkt_send_failure += 1;

--- a/hw_if/hal/src/common/hal_api_common.c
+++ b/hw_if/hal/src/common/hal_api_common.c
@@ -112,7 +112,7 @@ enum nrf_wifi_status hal_rpu_ps_wake(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 	did_rpu_had_sleep_opp(hal_dev_ctx);
 #endif /* NRF_WIFI_RPU_RECOVERY */
 #ifdef NRF_WIFI_RPU_RECOVERY_PS_STATE_DEBUG
-	nrf_wifi_osal_log_info("%s: RPU PS state is AWAKE\n",
+	nrf_wifi_osal_log_info("%s: RPU PS state is AWAKE",
 			       __func__);
 #endif /* NRF_WIFI_RPU_RECOVERY_PS_STATE_DEBUG */
 
@@ -143,7 +143,7 @@ static void hal_rpu_ps_sleep(unsigned long data)
 	hal_dev_ctx->rpu_ps_state = RPU_PS_STATE_ASLEEP;
 
 #ifdef NRF_WIFI_RPU_RECOVERY_PS_STATE_DEBUG
-	nrf_wifi_osal_log_info("%s: RPU PS state is ASLEEP\n",
+	nrf_wifi_osal_log_info("%s: RPU PS state is ASLEEP",
 			       __func__);
 #endif /* NRF_WIFI_RPU_RECOVERY_PS_STATE_DEBUG */
 	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->rpu_ps_lock,
@@ -580,11 +580,11 @@ enum nrf_wifi_status nrf_wifi_hal_ctrl_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 
 
 #ifdef CONFIG_NRF_WIFI_CMD_EVENT_LOG
-	nrf_wifi_osal_log_info("%s: caller %p\n",
+	nrf_wifi_osal_log_info("%s: caller %p",
 			      __func__,
 			      __builtin_return_address(0));
 #else
-	nrf_wifi_osal_log_dbg("%s: caller %p\n",
+	nrf_wifi_osal_log_dbg("%s: caller %p",
 			     __func__,
 			     __builtin_return_address(0));
 #endif

--- a/hw_if/hal/src/common/hal_fw_patch_loader.c
+++ b/hw_if/hal/src/common/hal_fw_patch_loader.c
@@ -288,7 +288,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 					   sleepctrl_addr,
 					   sleepctrl_val);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err("%s: Sleep control reg write failed for RPU(%d)\n",
+			nrf_wifi_osal_log_err("%s: Sleep control reg write failed for RPU(%d)",
 					      __func__,
 					      rpu_proc);
 
@@ -304,7 +304,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 					   boot_vector->addr,
 					   boot_vector->val);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err("%s: Writing boot vector failed for RPU(%d)\n",
+			nrf_wifi_osal_log_err("%s: Writing boot vector failed for RPU(%d)",
 					      __func__,
 					      rpu_proc);
 

--- a/hw_if/hal/src/common/hal_interrupt.c
+++ b/hw_if/hal/src/common/hal_interrupt.c
@@ -136,7 +136,7 @@ static bool hal_rpu_irq_wdog_chk(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 					RPU_REG_MIPS_MCU_UCCP_INT_STATUS);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err("%s: Reading from interrupt status register failed\n",
+			nrf_wifi_osal_log_err("%s: Reading from interrupt status register failed",
 						__func__);
 			goto out;
 		}
@@ -145,13 +145,13 @@ static bool hal_rpu_irq_wdog_chk(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 			break;
 		}
 
-		nrf_wifi_osal_log_err("%s: Reading from interrupt status register failed 0x%x\n",
+		nrf_wifi_osal_log_err("%s: Reading from interrupt status register failed 0x%x",
 					__func__,
 					val);
 	}
 
 	if (i == max_read_retries) {
-		nrf_wifi_osal_log_err("%s: Reading from interrupt status register failed 0x%x\n",
+		nrf_wifi_osal_log_err("%s: Reading from interrupt status register failed 0x%x",
 				      __func__,
 				      val);
 		goto out;

--- a/hw_if/hal/src/system/hal_api.c
+++ b/hw_if/hal/src/system/hal_api.c
@@ -137,7 +137,7 @@ unsigned long nrf_wifi_sys_hal_buf_map_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_c
 	unsigned long rpu_addr = 0;
 
 	if (!hal_dev_ctx || !hal_dev_ctx->rx_buf_info[pool_id]) {
-		nrf_wifi_osal_log_err("%s: Invalid parameters\n",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}


### PR DESCRIPTION
Remove trailing newline characters from the log messages. Most log messages do not have the newline, leading to inconsistency in output. The Zephyr logging backend already adds its own newlines.

Also cleans up some trailing whitespace and missing file end newlines my editor found.