### PR TITLE
Add nRF71 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ target_compile_definitions(
   $<$<BOOL:${CONFIG_NRF_WIFI_COEX_DISABLE_PRIORITY_WINDOW_FOR_SCAN}>:NRF_WIFI_COEX_DISABLE_PRIORITY_WINDOW_FOR_SCAN>
   $<$<BOOL:${CONFIG_NRF_WIFI_RX_STBC_HT}>:NRF_WIFI_RX_STBC_HT>
   $<$<BOOL:${CONFIG_NRF70_SR_COEX_SLEEP_CTRL_GPIO_CTRL}>:NRF70_SR_COEX_SLEEP_CTRL_GPIO_CTRL>
+  $<$<BOOL:${CONFIG_NRF71_ON_IPC}>:NRF71_ON_IPC>
   NRF_WIFI_MAX_PS_POLL_FAIL_CNT=${CONFIG_NRF_WIFI_MAX_PS_POLL_FAIL_CNT}
   NRF70_RX_NUM_BUFS=${CONFIG_NRF70_RX_NUM_BUFS}
   NRF70_MAX_TX_TOKENS=${CONFIG_NRF70_MAX_TX_TOKENS}
@@ -155,17 +156,22 @@ target_sources(nrf-wifi-osal PRIVATE
   ${NRF_WIFI_DIR}/utils/src/util.c
   ${NRF_WIFI_DIR}/hw_if/hal/src/common/hal_api_common.c
   ${NRF_WIFI_DIR}/hw_if/hal/src/common/hal_fw_patch_loader.c
-  ${NRF_WIFI_DIR}/hw_if/hal/src/common/hal_interrupt.c
-  ${NRF_WIFI_DIR}/hw_if/hal/src/common/hal_mem.c
-  ${NRF_WIFI_DIR}/hw_if/hal/src/common/hal_reg.c
-  ${NRF_WIFI_DIR}/hw_if/hal/src/common/hpqm.c
-  ${NRF_WIFI_DIR}/hw_if/hal/src/common/pal.c
   ${NRF_WIFI_DIR}/bus_if/bal/src/bal.c
   ${NRF_WIFI_DIR}/bus_if/bus/qspi/src/qspi.c
   ${NRF_WIFI_DIR}/fw_if/umac_if/src/common/fmac_cmd_common.c
   ${NRF_WIFI_DIR}/fw_if/umac_if/src/common/fmac_api_common.c
   ${NRF_WIFI_DIR}/fw_if/umac_if/src/common/fmac_util.c
 )
+
+if(NOT CONFIG_NRF71_ON_IPC)
+  target_sources(nrf-wifi-osal PRIVATE
+    ${NRF_WIFI_DIR}/hw_if/hal/src/common/hal_interrupt.c
+    ${NRF_WIFI_DIR}/hw_if/hal/src/common/hal_mem.c
+    ${NRF_WIFI_DIR}/hw_if/hal/src/common/hal_reg.c
+    ${NRF_WIFI_DIR}/hw_if/hal/src/common/hpqm.c
+    ${NRF_WIFI_DIR}/hw_if/hal/src/common/pal.c
+  )
+endif()
 
 if(CONFIG_NRF70_RADIO_TEST OR CONFIG_NRF70_BM_RADIO_TEST)
   target_sources(nrf-wifi-osal PRIVATE

--- a/fw_if/umac_if/src/common/fmac_api_common.c
+++ b/fw_if/umac_if/src/common/fmac_api_common.c
@@ -285,6 +285,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_chunk_load(struct nrf_wifi_fmac_dev_ctx *f
 				       fw_chunk->size);
 }
 
+#ifndef NRF71_ON_IPC
 enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					   struct nrf_wifi_fmac_fw_info *fmac_fw)
 {
@@ -353,13 +354,14 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 out:
 	return status;
 }
+#endif /* !NRF71_ON_IPC */
 
 
 enum nrf_wifi_status nrf_wifi_fmac_ver_get(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					  unsigned int *fw_ver)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
-
+#ifndef NRF71_ON_IPC
 	status = hal_rpu_mem_read(fmac_dev_ctx->hal_dev_ctx,
 				  fw_ver,
 				  RPU_MEM_UMAC_VER,
@@ -372,10 +374,14 @@ enum nrf_wifi_status nrf_wifi_fmac_ver_get(struct nrf_wifi_fmac_dev_ctx *fmac_de
 	}
 
 out:
+#else
+	*fw_ver = 0x01020304;
+	status = NRF_WIFI_STATUS_SUCCESS;
+#endif /* !NRF71_ON_IPC */
 	return status;
 }
 
-
+#ifndef NRF71_ON_IPC
 enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 						    unsigned char vif_idx,
 						    unsigned char *mac_addr)
@@ -440,6 +446,7 @@ enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx
 out:
 	return status;
 }
+#endif /*! NRF71_ON_IPC */
 
 enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					   struct nrf_wifi_fmac_reg_info *reg_info)

--- a/fw_if/umac_if/src/system/fmac_api.c
+++ b/fw_if/umac_if/src/system/fmac_api.c
@@ -385,7 +385,9 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fm
 					    unsigned char *country_code)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
-	struct nrf_wifi_fmac_otp_info otp_info;
+#ifndef NRF71_ON_IPC
+        struct nrf_wifi_fmac_otp_info otp_info;
+#endif /* !NRF71_ON_IPC */
 	struct nrf_wifi_phy_rf_params phy_rf_params;
 
 	if (!fmac_dev_ctx) {
@@ -413,6 +415,7 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fm
 		goto out;
 	}
 
+#ifndef NRF71_ON_IPC
 	nrf_wifi_osal_mem_set(&otp_info,
 			      0xFF,
 			      sizeof(otp_info));
@@ -434,6 +437,7 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fm
 				      __func__);
 		goto out;
 	}
+#endif /* !NRF71_ON_IPC */
 
 	status = nrf_wifi_sys_fmac_fw_init(fmac_dev_ctx,
 				       &phy_rf_params,

--- a/fw_if/umac_if/src/system/fmac_peer.c
+++ b/fw_if/umac_if/src/system/fmac_peer.c
@@ -78,6 +78,7 @@ int nrf_wifi_fmac_peer_add(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 			peer->peer_id = i;
 			peer->is_legacy = is_legacy;
 			peer->qos_supported = qos_supported;
+#ifndef NRF71_ON_IPC
 			if (vif_ctx->if_type == NRF_WIFI_IFTYPE_AP) {
 				hal_rpu_mem_write(fmac_dev_ctx->hal_dev_ctx,
 						  (RPU_MEM_UMAC_PEND_Q_BMP +
@@ -85,10 +86,10 @@ int nrf_wifi_fmac_peer_add(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 						  peer->ra_addr,
 						  NRF_WIFI_FMAC_ETH_ADDR_LEN);
 			}
+#endif /* !NRF71_ON_IPC */
 			return i;
 		}
 	}
-
 	nrf_wifi_osal_log_err("%s: Failed !! No Space Available",
 			      __func__);
 
@@ -118,6 +119,7 @@ void nrf_wifi_fmac_peer_remove(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		return;
 	}
 
+#ifndef NRF71_ON_IPC
 	if (vif_ctx->if_type == NRF_WIFI_IFTYPE_AP) {
 		hal_rpu_mem_write(fmac_dev_ctx->hal_dev_ctx,
 				  (RPU_MEM_UMAC_PEND_Q_BMP +
@@ -125,7 +127,7 @@ void nrf_wifi_fmac_peer_remove(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 				  peer->ra_addr,
 				  NRF_WIFI_FMAC_ETH_ADDR_LEN);
 	}
-
+#endif /* !NRF71_ON_IPC */
 	nrf_wifi_osal_mem_set(peer,
 			      0x0,
 			      sizeof(struct peers_info));

--- a/hw_if/hal/inc/common/hal_structs_common.h
+++ b/hw_if/hal/inc/common/hal_structs_common.h
@@ -111,6 +111,7 @@ enum NRF_WIFI_HAL_STATUS {
 	NRF_WIFI_HAL_STATUS_DISABLED,
 };
 
+#ifndef NRF71_ON_IPC
 /**
  * @brief Structure to hold RPU information.
  */
@@ -122,6 +123,7 @@ struct nrf_wifi_hal_info {
 	/** TX command base */
 	unsigned int tx_cmd_base;
 };
+#endif /* !NRF71_ON_IPC */
 
 /**
  * @brief Structure to hold buffer mapping information for the HAL layer.
@@ -195,7 +197,6 @@ struct nrf_wifi_hal_priv {
 	unsigned long addr_pktram_base;
 };
 
-
 /**
  * @brief Structure to hold per device context information for the HAL layer.
  */
@@ -209,7 +210,11 @@ struct nrf_wifi_hal_dev_ctx {
 	/** Device index */
 	unsigned char idx;
 	/** RPU information */
+#ifndef NRF71_ON_IPC
 	struct nrf_wifi_hal_info rpu_info;
+#else /* NRF71_ON_IPC */
+	void *ipc_msg;
+#endif /* !NRF71_ON_IPC */
 	/** Number of commands */
 	unsigned int num_cmds;
 	/** Command queue */

--- a/os_if/inc/osal_api.h
+++ b/os_if/inc/osal_api.h
@@ -1303,4 +1303,11 @@ int nrf_wifi_osal_mem_cmp(const void *addr1,
  * 			returns an 8 bit random number.
  */
 unsigned char nrf_wifi_osal_rand8_get(void);
+
+#ifdef NRF71_ON_IPC
+int nrf_wifi_osal_ipc_send_msg(unsigned int msg_type,
+	void *msg,
+	unsigned int msg_len);
+#endif /* NRF71_ON_IPC */
+
 #endif /* __OSAL_API_H__ */

--- a/os_if/inc/osal_ops.h
+++ b/os_if/inc/osal_ops.h
@@ -959,5 +959,8 @@ struct nrf_wifi_osal_ops {
 	 * @return A random 8-bit value.
 	 */
 	unsigned char (*rand8_get)(void);
+#ifdef NRF71_ON_IPC
+	int (*ipc_send_msg)(unsigned int msg_type, void *msg, unsigned int msg_len);
+#endif /* NRF71_ON_IPC */
 };
 #endif /* __OSAL_OPS_H__ */

--- a/os_if/src/osal.c
+++ b/os_if/src/osal.c
@@ -858,3 +858,12 @@ unsigned char nrf_wifi_osal_rand8_get(void)
 {
 	return os_ops->rand8_get();
 }
+
+#ifdef NRF71_ON_IPC
+int nrf_wifi_osal_ipc_send_msg(unsigned int msg_type,
+				 void *msg,
+				 unsigned int msg_len)
+{
+	return os_ops->ipc_send_msg(msg_type, msg, msg_len);
+}
+#endif /* NRF71_ON_IPC */


### PR DESCRIPTION
nRF71 is a combo SoC that uses IPC to communicate between the APP and Wi-Fi cores. This is a preliminary support that removes HPQM, Firmware loading, any direct memory access to the Wi-Fi domain etc for nRF71 using a define.