### PR TITLE
fw_if: system: Remove station mode from monitor mode

### DIFF
--- a/fw_if/umac_if/inc/system/fmac_structs.h
+++ b/fw_if/umac_if/inc/system/fmac_structs.h
@@ -143,6 +143,14 @@ struct nrf_wifi_fmac_callbk_fns {
 	void (*event_get_reg)(void *if_priv,
 		struct nrf_wifi_reg *get_reg,
 		unsigned int event_len);
+
+#if defined(NRF70_STA_MODE) || defined(NRF70_RAW_DATA_RX) || defined(__DOXYGEN__)
+	/** Callback function to be called when a set interface response is received. */
+	void (*set_if_callbk_fn)(void *os_vif_ctx,
+				 struct nrf_wifi_umac_event_set_interface *set_if_event,
+				 unsigned int event_len);
+#endif
+
 #if defined(NRF70_STA_MODE) || defined(__DOXYGEN__)
 	/** Callback function to be called when an interface association state changes. */
 	enum nrf_wifi_status (*if_carr_state_chg_callbk_fn)(void *os_vif_ctx,
@@ -201,11 +209,6 @@ struct nrf_wifi_fmac_callbk_fns {
 	void (*tx_status_callbk_fn)(void *os_vif_ctx,
 				    struct nrf_wifi_umac_event_mlme *tx_status_event,
 				    unsigned int event_len);
-
-	/** Callback function to be called when a set interface response is received. */
-	void (*set_if_callbk_fn)(void *os_vif_ctx,
-				 struct nrf_wifi_umac_event_set_interface *set_if_event,
-				 unsigned int event_len);
 
 	/** Callback function to be called when a remain on channel response is received. */
 	void (*roc_callbk_fn)(void *os_vif_ctx,
@@ -290,7 +293,9 @@ enum nrf_wifi_fmac_twt_state {
 	/** RPU in TWT awake state. */
 	NRF_WIFI_FMAC_TWT_STATE_AWAKE
 };
+#endif /* NRF70_STA_MODE */
 
+#if defined(NRF70_STA_MODE) || defined(NRF70_RAW_DATA_RX) || defined(__DOXYGEN__)
 /**
  * @brief Structure to hold peer context information.
  *
@@ -353,7 +358,7 @@ struct tx_config {
 	void *tx_done_tasklet_event_q;
 #endif /* NRF70_TX_DONE_WQ_ENABLED */
 };
-#endif /* NRF70_STA_MODE */
+#endif /* NRF70_STA_MODE || NRF70_RAW_DATA_RX */
 
 /**
  * @brief Structure to hold context information for the UMAC IF layer.
@@ -469,11 +474,13 @@ struct nrf_wifi_sys_fmac_dev_ctx {
 	unsigned char num_ap;
 	/** Queue for storing mapping info of RX buffers. */
 	struct nrf_wifi_fmac_buf_map_info *rx_buf_info;
+#if defined(NRF70_STA_MODE) || defined(NRF70_RAW_DATA_RX)
+	/** Context information related to TX path. */
+	struct tx_config tx_config;
+#endif
 #if defined(NRF70_STA_MODE)
 	/** Queue for storing mapping info of TX buffers. */
 	struct nrf_wifi_fmac_buf_map_info *tx_buf_info;
-	/** Context information related to TX path. */
-	struct tx_config tx_config;
 	/** TWT state of the RPU. */
 	enum nrf_wifi_fmac_twt_state twt_sleep_status;
 #if defined(NRF70_TX_DONE_WQ_ENABLED)

--- a/fw_if/umac_if/src/system/fmac_event.c
+++ b/fw_if/umac_if/src/system/fmac_event.c
@@ -637,6 +637,18 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 		}
 		vif_ctx->ifflags = true;
 		break;
+#if defined(NRF70_STA_MODE) || defined(NRF70_RAW_DATA_RX)
+	case NRF_WIFI_UMAC_EVENT_SET_INTERFACE:
+		if (callbk_fns->set_if_callbk_fn)
+			callbk_fns->set_if_callbk_fn(vif_ctx->os_vif_ctx,
+						     event_data,
+						     event_len);
+		else
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
+					      __func__,
+					      umac_hdr->cmd_evnt);
+		break;
+#endif
 #ifdef NRF70_STA_MODE
 	case NRF_WIFI_UMAC_EVENT_TWT_SLEEP:
 		if (callbk_fns->twt_sleep_callbk_fn)
@@ -778,16 +790,6 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 			callbk_fns->unprot_mlme_mgmt_rx_callbk_fn(vif_ctx->os_vif_ctx,
 								  event_data,
 								  event_len);
-		else
-			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
-					      __func__,
-					      umac_hdr->cmd_evnt);
-		break;
-	case NRF_WIFI_UMAC_EVENT_SET_INTERFACE:
-		if (callbk_fns->set_if_callbk_fn)
-			callbk_fns->set_if_callbk_fn(vif_ctx->os_vif_ctx,
-						     event_data,
-						     event_len);
 		else
 			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,


### PR DESCRIPTION
Monitor mode doesn't require station mode. Disabling station mode require necessary changes to work monitor mode.