### PR TITLE
Fix Raw TX handling

### DIFF
--- a/fw_if/umac_if/inc/system/fmac_structs.h
+++ b/fw_if/umac_if/inc/system/fmac_structs.h
@@ -426,8 +426,6 @@ struct raw_tx_pkt_header {
 	unsigned char tx_mode;
 	/** Wi-Fi access category mapping for packet @ref nrf_wifi_fmac_ac. */
 	unsigned char queue;
-	/** Flag indicating raw packet transmission. */
-	unsigned char raw_tx_flag;
 };
 
 /**

--- a/os_if/inc/osal_api.h
+++ b/os_if/inc/osal_api.h
@@ -621,6 +621,40 @@ unsigned char nrf_wifi_osal_nbuf_get_chksum_done(void *nbuf);
 void nrf_wifi_osal_nbuf_set_chksum_done(void *nbuf,
 					unsigned char chksum_done);
 
+#if defined(CONFIG_NRF70_RAW_DATA_TX) || defined(__DOXYGEN__)
+/**
+ * @brief Set the raw Tx header in a network buffer.
+ * @param nbuf Pointer to a network buffer.
+ * @param raw_hdr_len Length of the raw Tx header to be set.
+ *
+ * Sets the raw Tx header in a network buffer.
+ *
+ * * @return Pointer to the raw Tx header if successful, NULL otherwise.
+ */
+void *nrf_wifi_osal_nbuf_set_raw_tx_hdr(void *nbuf,
+					unsigned short raw_hdr_len);
+
+/**
+ * @brief Get the raw Tx header from a network buffer.
+ * @param nbuf Pointer to a network buffer.
+ *
+ * Gets the raw Tx header from a network buffer.
+ *
+ * @return Pointer to the raw Tx header if successful, NULL otherwise.
+ */
+void *nrf_wifi_osal_nbuf_get_raw_tx_hdr(void *nbuf);
+
+/**
+ * @brief Check if a network buffer is a raw Tx buffer.
+ * @param nbuf Pointer to a network buffer.
+ *
+ * Checks if a network buffer is a raw Tx buffer.
+ *
+ * @return true if the network buffer is a raw Tx buffer, false otherwise.
+ */
+bool nrf_wifi_osal_nbuf_is_raw_tx(void *nbuf);
+#endif /* CONFIG_NRF70_RAW_DATA_TX || __DOXYGEN__ */
+
 /**
  * @brief Allocate a tasklet.
  * @param type Type of tasklet.

--- a/os_if/inc/osal_ops.h
+++ b/os_if/inc/osal_ops.h
@@ -524,7 +524,31 @@ struct nrf_wifi_osal_ops {
 	 * @param chksum_done The checksum status to set.
 	 */
 	void (*nbuf_set_chksum_done)(void *nbuf, unsigned char chksum_done);
+#if defined(NRF70_RAW_DATA_TX) || defined(__DOXYGEN__)
+	/**
+	 * @brief Set the raw Tx header in a network buffer.
+	 *
+	 * @param nbuf A pointer to the network buffer.
+	 * @param raw_hdr_len The length of the raw header to set.
+	 */
+	void *(*nbuf_set_raw_tx_hdr)(void *nbuf, unsigned short raw_hdr_len);
+	/**
+	 * @brief Get the raw Tx header from a network buffer.
+	 *
+	 * @param nbuf A pointer to the network buffer.
+	 * @return A pointer to the raw Tx header.
+	 */
+	void *(*nbuf_get_raw_tx_hdr)(void *nbuf);
 
+	/**
+	 * @brief Check if the network buffer is a raw Tx buffer.
+	 *
+	 * @param nbuf A pointer to the network buffer.
+	 *
+	 * @return true if it is a raw Tx buffer, false otherwise.
+	 */
+	bool (*nbuf_is_raw_tx)(void *nbuf);
+#endif /* NRF70_RAW_DATA_TX || __DOXYGEN__ */
 	/**
 	 * @brief Allocate a tasklet structure.
 	 *

--- a/os_if/src/osal.c
+++ b/os_if/src/osal.c
@@ -416,6 +416,25 @@ void nrf_wifi_osal_nbuf_set_chksum_done(void *nbuf,
 	return os_ops->nbuf_set_chksum_done(nbuf, chksum_done);
 }
 
+#ifdef CONFIG_NRF70_RAW_DATA_TX
+void *nrf_wifi_osal_nbuf_set_raw_tx_hdr(void *nbuf,
+					unsigned short raw_hdr_len)
+{
+	return os_ops->nbuf_set_raw_tx_hdr(nbuf,
+				      raw_hdr_len);
+}
+
+void *nrf_wifi_osal_nbuf_get_raw_tx_hdr(void *nbuf)
+{
+	return os_ops->nbuf_get_raw_tx_hdr(nbuf);
+}
+
+bool nrf_wifi_osal_nbuf_is_raw_tx(void *nbuf)
+{
+	return os_ops->nbuf_is_raw_tx(nbuf);
+}
+#endif /* CONFIG_NRF70_RAW_DATA_TX */
+
 
 void *nrf_wifi_osal_tasklet_alloc(int type)
 {


### PR DESCRIPTION
Using a flag for per-packet handling is not ideal, esp. that flash is cleared after TX, but in case of pending raw TX packets that will be processed through TX done flag is unset and they won't be processed.

Move the check to per-packet and add APIs to set/get/check, this way it's a clean implementation and handles sending from both TX and TX_DONE paths.

This is a breaking change as the raw TX header is modified.