### PR TITLE
nrf_wifi: Host need to pass connection type

### DIFF
--- a/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
+++ b/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
@@ -1323,6 +1323,18 @@ struct nrf_wifi_umac_cmd_auth {
 #define NRF_WIFI_CMD_ASSOCIATE_MAC_ADDR_VALID (1 << 0)
 
 /**
+ * @brief Types of connection protected/un-protected.
+ *
+ */
+
+enum nrf_wifi_conn_type {
+	/* Connection to be non-protected */
+	NRF_WIFI_CONN_TYPE_OPEN,
+	/* Connection to be protected */
+	NRF_WIFI_CONN_TYPE_SECURE,
+};
+
+/**
  * @brief This structure specifies the parameters to be used when sending an association request.
  *
  */
@@ -1351,6 +1363,8 @@ struct nrf_wifi_umac_assoc_info {
 	 *  BSS MAX IDLE IE in assoc request frame.
 	 */
 	unsigned short bss_max_idle_time;
+	/** Connection type */
+	unsigned char conn_type;
 } __NRF_WIFI_PKD;
 
 /**

--- a/fw_if/umac_if/src/system/fmac_api.c
+++ b/fw_if/umac_if/src/system/fmac_api.c
@@ -979,6 +979,11 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_assoc(void *dev_ctx,
 		connect_common_info->maxidle_insec = assoc_info->bss_max_idle_time;
 	}
 
+	if (assoc_info->conn_type == NRF_WIFI_CONN_TYPE_SECURE) {
+		connect_common_info->nrf_wifi_flags |=
+			NRF_WIFI_CONNECT_COMMON_INFO_SECURITY;
+	}
+
 	status = umac_cmd_cfg(fmac_dev_ctx,
 			      assoc_cmd,
 			      sizeof(*assoc_cmd));


### PR DESCRIPTION
Firmware need to the connection type depending upon which it it may take some action. So host need to pass connection type protected or open to firmware.