### PR TITLE
nrf_wifi: Update shared hdr files for TWT timeout

### DIFF
--- a/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
+++ b/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
@@ -2402,6 +2402,10 @@ struct nrf_wifi_umac_config_twt_info {
 	unsigned char twt_resp_status;
         /** TWT early wake duration */
         unsigned int twt_wake_ahead_duration;
+	/** Timeout value (in milliseconds) used by the RPU to send TWT requests
+	 *  to the AP before receiving a TWT response from the AP.
+	 */
+	unsigned int twt_req_timeout;
 } __NRF_WIFI_PKD;
 
 /**

--- a/fw_if/umac_if/inc/fw/patch_info.h
+++ b/fw_if/umac_if/inc/fw/patch_info.h
@@ -62,7 +62,7 @@ struct nrf70_fw_image_info {
 #define RPU_FAMILY         (1)
 #define RPU_MAJOR_VERSION   (2)
 #define RPU_MINOR_VERSION   (13)
-#define RPU_PATCH_VERSION   (0)
+#define RPU_PATCH_VERSION   (1)
 
 /**
  * @}


### PR DESCRIPTION
Update RPU shared header files to set TWT timeout
from Kconfig option and update rpu patch version
1.2.13.0 to 1.2.13.1.