### PR TITLE
fw_if: do not redefine MIN

### DIFF
--- a/fw_if/umac_if/inc/common/fmac_api_common.h
+++ b/fw_if/umac_if/inc/common/fmac_api_common.h
@@ -23,7 +23,9 @@
 
 #include <patch_info.h>
 
+#ifndef MIN
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
 
 /**
  * @brief De-initialize the UMAC IF layer.


### PR DESCRIPTION
Add an ifndef guard to avoid redefining MIN, similarly to how it's already done for ARRAY_SIZE. This prevents potential collisions with the upstream MIN depending on the include order.