### PR TITLE
Fix typo

### DIFF
--- a/fw_if/umac_if/src/offload_raw_tx/fmac_cmd.c
+++ b/fw_if/umac_if/src/offload_raw_tx/fmac_cmd.c
@@ -89,7 +89,7 @@ enum nrf_wifi_status umac_cmd_off_raw_tx_init(struct nrf_wifi_fmac_dev_ctx *fmac
 	umac_cmd_data->keep_alive_enable = KEEP_ALIVE_ENABLED;
 	umac_cmd_data->keep_alive_period = NRF_WIFI_KEEPALIVE_PERIOD_S;
 	nrf_wifi_osal_log_dbg("Keepalive enabled with period %d",
-				   umac_cmd_data->keepalive_period);
+				   umac_cmd_data->keep_alive_period);
 #endif /* NRF_WIFI_FEAT_KEEPALIVE */
 
 	umac_cmd_data->op_band = op_band;

--- a/fw_if/umac_if/src/radio_test/fmac_cmd.c
+++ b/fw_if/umac_if/src/radio_test/fmac_cmd.c
@@ -89,7 +89,7 @@ enum nrf_wifi_status umac_cmd_rt_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx
 	umac_cmd_data->keep_alive_enable = KEEP_ALIVE_ENABLED;
 	umac_cmd_data->keep_alive_period = NRF_WIFI_KEEPALIVE_PERIOD_S;
 	nrf_wifi_osal_log_dbg("Keepalive enabled with period %d",
-				   umac_cmd_data->keepalive_period);
+				   umac_cmd_data->keep_alive_period);
 #endif /* NRF_WIFI_FEAT_KEEPALIVE */
 
 	umac_cmd_data->op_band = op_band;

--- a/fw_if/umac_if/src/system/fmac_cmd.c
+++ b/fw_if/umac_if/src/system/fmac_cmd.c
@@ -95,7 +95,7 @@ enum nrf_wifi_status umac_cmd_sys_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 	umac_cmd_data->keep_alive_enable = KEEP_ALIVE_ENABLED;
 	umac_cmd_data->keep_alive_period = NRF_WIFI_KEEPALIVE_PERIOD_S;
 	nrf_wifi_osal_log_dbg("Keepalive enabled with period %d",
-				   umac_cmd_data->keepalive_period);
+				   umac_cmd_data->keep_alive_period);
 #endif /* NRF_WIFI_FEAT_KEEPALIVE */
 
 	nrf_wifi_osal_mem_cpy(umac_cmd_data->rx_buf_pools,


### PR DESCRIPTION
keepalive_period changed to keep_alive_period

Discovered this while working on [nrf70-bm](https://github.com/nrfconnect/nrf70-bm) with enhanced logging. This fix should therefore be propagated downstream.