### PR TITLE
nrf_wifi: system: Support to set extended sleep

### DIFF
--- a/fw_if/umac_if/inc/system/fmac_api.h
+++ b/fw_if/umac_if/inc/system/fmac_api.h
@@ -1140,6 +1140,26 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_set_tx_rate(struct nrf_wifi_fmac_dev_ctx 
 enum nrf_wifi_status nrf_wifi_sys_fmac_get_host_rpu_ps_ctrl_state(void *fmac_dev_ctx,
 								  int *rpu_ps_ctrl_state);
 #endif /* NRF_WIFI_LOW_POWER */
+
+/**
+ * @brief Request an extended sleep interval for the nRF70.
+ * @param fmac_dev_ctx Pointer to the UMAC IF context for a RPU WLAN device.
+ * @param if_idx Index of the interface on which the request is issued.
+ * @param duration_sec Duration of the extended sleep interval in seconds.
+ *
+ * Requests that the RPU remain in deep sleep for @p duration_sec without
+ * waking for DTIM beacons. This allows lower power consumption at the cost
+ * of missed Wi-Fi traffic: no frames are received when device is in extended sleep.
+ *
+ * This function sends %NRF_WIFI_UMAC_CMD_CONFIG_QUIET_PERIOD to the RPU
+ * firmware.
+ *
+ * @retval NRF_WIFI_STATUS_SUCCESS On success.
+ * @retval NRF_WIFI_STATUS_FAIL On failure to execute command.
+ */
+enum nrf_wifi_status nrf_wifi_fmac_req_extended_sleep(void *fmac_dev_ctx,
+						      unsigned char if_idx,
+						      unsigned int duration_sec);
 #endif /* NRF70_UTIL */
 
 /**

--- a/fw_if/umac_if/src/system/fmac_api.c
+++ b/fw_if/umac_if/src/system/fmac_api.c
@@ -3986,6 +3986,51 @@ out:
 	return status;
 }
 #endif /* NRF_WIFI_LOW_POWER */
+
+enum nrf_wifi_status nrf_wifi_fmac_req_extended_sleep(void *dev_ctx,
+						      unsigned char if_idx,
+						      unsigned int duration_sec)
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	struct nrf_wifi_umac_cmd_config_quiet_period *set_quiet_period_cmd = NULL;
+	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
+
+	fmac_dev_ctx = dev_ctx;
+
+	if (!fmac_dev_ctx) {
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
+				      __func__);
+		goto out;
+	}
+
+	if (fmac_dev_ctx->op_mode != NRF_WIFI_OP_MODE_SYS) {
+		nrf_wifi_osal_log_err("%s: Invalid op mode",
+				      __func__);
+		goto out;
+	}
+
+	set_quiet_period_cmd = nrf_wifi_osal_mem_zalloc(sizeof(*set_quiet_period_cmd));
+
+	if (!set_quiet_period_cmd) {
+		nrf_wifi_osal_log_err("%s: Unable to allocate memory",
+				      __func__);
+		goto out;
+	}
+
+	set_quiet_period_cmd->umac_hdr.cmd_evnt = NRF_WIFI_UMAC_CMD_CONFIG_QUIET_PERIOD;
+	set_quiet_period_cmd->umac_hdr.ids.wdev_id = if_idx;
+	set_quiet_period_cmd->umac_hdr.ids.valid_fields |=
+		NRF_WIFI_INDEX_IDS_WDEV_ID_VALID;
+	set_quiet_period_cmd->quiet_period_in_sec = duration_sec;
+
+	status = umac_cmd_cfg(fmac_dev_ctx,
+			      set_quiet_period_cmd,
+			      sizeof(*set_quiet_period_cmd));
+out:
+	nrf_wifi_osal_mem_free(set_quiet_period_cmd);
+
+	return status;
+}
 #endif /* NRF70_UTIL */
 
 


### PR DESCRIPTION
Quiet period is the period during which STA will stop all types of TX/RX. Add a UMAC command to configure the quiet period.